### PR TITLE
fix: correct skip counting, unicode nodeids, and fixture event loop

### DIFF
--- a/src/execution/scheduler.rs
+++ b/src/execution/scheduler.rs
@@ -301,7 +301,12 @@ impl Scheduler {
                         "Worker crashed during test execution"
                     };
                     self.finalize_crashed_worker(
-                        test_id, &test_name, slot, "crash", crash_phase, reporter,
+                        test_id,
+                        &test_name,
+                        slot,
+                        "crash",
+                        crash_phase,
+                        reporter,
                     );
                     failed += 1;
                     collected += 1;
@@ -319,7 +324,12 @@ impl Scheduler {
                     }
 
                     self.finalize_crashed_worker(
-                        test_id, &test_name, slot, "timeout", "Test exceeded timeout limit", reporter,
+                        test_id,
+                        &test_name,
+                        slot,
+                        "timeout",
+                        "Test exceeded timeout limit",
+                        reporter,
                     );
                     failed += 1;
                     collected += 1;
@@ -368,7 +378,12 @@ impl Scheduler {
                         "Worker crashed during test execution"
                     };
                     self.finalize_crashed_worker(
-                        test_id, &test_name, slot, "crash", crash_phase, reporter,
+                        test_id,
+                        &test_name,
+                        slot,
+                        "crash",
+                        crash_phase,
+                        reporter,
                     );
                     failed += 1;
                     collected += 1;
@@ -386,7 +401,12 @@ impl Scheduler {
                     }
 
                     self.finalize_crashed_worker(
-                        test_id, &test_name, slot, "timeout", "Test exceeded timeout limit", reporter,
+                        test_id,
+                        &test_name,
+                        slot,
+                        "timeout",
+                        "Test exceeded timeout limit",
+                        reporter,
                     );
                     failed += 1;
                     collected += 1;

--- a/src/reporting/reporter.rs
+++ b/src/reporting/reporter.rs
@@ -482,29 +482,30 @@ impl Reporter for HumanReporter {
         message: Option<&str>,
     ) {
         let use_colors = supports_colors();
-        match status {
-            "pass" => eprintln!("ok ({}ms)", duration_ms),
-            "fail" => {
-                if use_colors {
-                    eprintln!("{}FAILED{} ({}ms)", ANSI_RED, ANSI_RESET, duration_ms);
-                } else {
-                    eprintln!("FAILED ({}ms)", duration_ms);
-                }
-                if let Some(msg) = message {
-                    // Format traceback according to style
-                    let formatted = format_traceback(msg, id, self.traceback_style);
-                    if !formatted.is_empty() {
-                        // Apply colorization if terminal supports it
-                        let colorized = colorize_traceback(&formatted, use_colors);
-                        // Indent failure message
-                        for line in colorized.lines().take(20) {
-                            eprintln!("    {}", line);
-                        }
+        if status.eq_ignore_ascii_case("pass") {
+            eprintln!("ok ({}ms)", duration_ms);
+        } else if status.eq_ignore_ascii_case("fail") {
+            if use_colors {
+                eprintln!("{}FAILED{} ({}ms)", ANSI_RED, ANSI_RESET, duration_ms);
+            } else {
+                eprintln!("FAILED ({}ms)", duration_ms);
+            }
+            if let Some(msg) = message {
+                // Format traceback according to style
+                let formatted = format_traceback(msg, id, self.traceback_style);
+                if !formatted.is_empty() {
+                    // Apply colorization if terminal supports it
+                    let colorized = colorize_traceback(&formatted, use_colors);
+                    // Indent failure message
+                    for line in colorized.lines().take(20) {
+                        eprintln!("    {}", line);
                     }
                 }
             }
-            "skip" => eprintln!("skipped"),
-            _ => eprintln!("{}", status),
+        } else if status.eq_ignore_ascii_case("skip") {
+            eprintln!("skipped");
+        } else {
+            eprintln!("{}", status);
         }
     }
 
@@ -697,25 +698,24 @@ impl Reporter for ProgressReporter {
         _duration_ms: u64,
         message: Option<&str>,
     ) {
-        match status {
-            "pass" => self.passed += 1,
-            "fail" => {
-                self.failed += 1;
-                // Format and buffer failure for summary with colorization
-                let use_colors = supports_colors();
-                let formatted_msg = message
-                    .map(|m| {
-                        let formatted = format_traceback(m, id, self.traceback_style);
-                        colorize_traceback(&formatted, use_colors)
-                    })
-                    .unwrap_or_default();
-                self.failures.push(FailureRecord {
-                    id: id.to_string(),
-                    message: formatted_msg,
-                });
-            }
-            "skip" => self.skipped += 1,
-            _ => {}
+        if status.eq_ignore_ascii_case("pass") {
+            self.passed += 1;
+        } else if status.eq_ignore_ascii_case("fail") {
+            self.failed += 1;
+            // Format and buffer failure for summary with colorization
+            let use_colors = supports_colors();
+            let formatted_msg = message
+                .map(|m| {
+                    let formatted = format_traceback(m, id, self.traceback_style);
+                    colorize_traceback(&formatted, use_colors)
+                })
+                .unwrap_or_default();
+            self.failures.push(FailureRecord {
+                id: id.to_string(),
+                message: formatted_msg,
+            });
+        } else if status.eq_ignore_ascii_case("skip") {
+            self.skipped += 1;
         }
 
         self.bar.inc(1);
@@ -879,34 +879,29 @@ impl Reporter for DotsReporter {
         _duration_ms: u64,
         message: Option<&str>,
     ) {
-        match status {
-            "pass" => {
-                self.passed += 1;
-                self.print_char('.');
-            }
-            "fail" => {
-                self.failed += 1;
-                self.print_char('F');
-                // Format and buffer failure for summary with colorization
-                let use_colors = supports_colors();
-                let formatted_msg = message
-                    .map(|m| {
-                        let formatted = format_traceback(m, id, self.traceback_style);
-                        colorize_traceback(&formatted, use_colors)
-                    })
-                    .unwrap_or_default();
-                self.failures.push(FailureRecord {
-                    id: id.to_string(),
-                    message: formatted_msg,
-                });
-            }
-            "skip" => {
-                self.skipped += 1;
-                self.print_char('s');
-            }
-            _ => {
-                self.print_char('?');
-            }
+        if status.eq_ignore_ascii_case("pass") {
+            self.passed += 1;
+            self.print_char('.');
+        } else if status.eq_ignore_ascii_case("fail") {
+            self.failed += 1;
+            self.print_char('F');
+            // Format and buffer failure for summary with colorization
+            let use_colors = supports_colors();
+            let formatted_msg = message
+                .map(|m| {
+                    let formatted = format_traceback(m, id, self.traceback_style);
+                    colorize_traceback(&formatted, use_colors)
+                })
+                .unwrap_or_default();
+            self.failures.push(FailureRecord {
+                id: id.to_string(),
+                message: formatted_msg,
+            });
+        } else if status.eq_ignore_ascii_case("skip") {
+            self.skipped += 1;
+            self.print_char('s');
+        } else {
+            self.print_char('?');
         }
     }
 

--- a/src/tach_harness.py
+++ b/src/tach_harness.py
@@ -3836,6 +3836,20 @@ def run_test(
         if not target_item:
             target_item = _ITEMS_MAP.get(node_id)
 
+        # Fallback for Unicode nodeids (Issue #XX): pytest may escape Unicode chars
+        # differently than Rust discovery. Try matching by file basename + test name.
+        if not target_item:
+            # Match by file basename + test part to avoid false positives
+            constructed_file: str = constructed_nodeid.split("::")[0] if "::" in constructed_nodeid else ""
+            constructed_test: str = constructed_nodeid.split("::")[-1] if "::" in constructed_nodeid else constructed_nodeid
+            for key, item in _ITEMS_MAP.items():
+                key_file: str = key.split("::")[0] if "::" in key else ""
+                key_test: str = key.split("::")[-1] if "::" in key else key
+                # Match if file basenames match AND test parts match
+                if os.path.basename(key_file) == os.path.basename(constructed_file) and key_test == constructed_test:
+                    target_item = item
+                    break
+
         if not target_item:
             duration = time.perf_counter() - start
             # Include both attempted nodeids in error for debugging
@@ -3896,6 +3910,17 @@ def run_test(
         # Parse marker_info to get django_db settings and apply SAVEPOINT isolation
         django_db_args = _parse_django_db_marker(marker_info)
         django_savepoints = _apply_django_db_isolation(django_db_args)
+
+        # Event Loop Setup: ensure a loop exists for fixtures
+        # Check if loop already exists to avoid orphaning
+        try:
+            _fixture_loop = asyncio.get_event_loop()
+            if _fixture_loop.is_closed():
+                _fixture_loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(_fixture_loop)
+        except RuntimeError:
+            _fixture_loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(_fixture_loop)
 
         # Django Fixtures (v0.3.0 - Issue #39)
         # Setup fixtures after db isolation is applied


### PR DESCRIPTION
## Summary
- Fix skip status counting: Changed reporter.rs to use `eq_ignore_ascii_case()` for case-insensitive status matching
- Fix Unicode nodeid mismatch: Added fallback lookup matching file basename + test name for parametrized tests with Chinese characters
- Fix fixture event loop: Ensure event loop exists before fixtures run

## Test plan
- [x] All 801 unit tests pass
- [x] Clippy clean
- [x] Format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test item resolution with fallback matching for Unicode and escaped characters.
  * Enhanced event loop initialization to prevent missing or orphaned loops during test execution.

* **Refactor**
  * Restructured internal status handling logic for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->