### PR TITLE
fix(harness): scope-aware async fixture handling

### DIFF
--- a/src/tach_harness.py
+++ b/src/tach_harness.py
@@ -78,6 +78,20 @@ class EventLoopManager:
             cls._instance.close_all()
             cls._instance = None
 
+    @classmethod
+    def get_current_loop(cls) -> Optional[asyncio.AbstractEventLoop]:
+        """Get the most recently created valid loop, or None.
+
+        This provides encapsulated access to the managed loops without
+        exposing internal _loops dictionary.
+        """
+        instance = cls.get_instance()
+        for key in reversed(list(instance._loops.keys())):
+            loop = instance._loops[key]
+            if loop and not loop.is_closed():
+                return loop
+        return None
+
     def configure(self, loop_scope: str = "function", auto_mode: bool = False) -> None:
         """Configure loop scope and auto mode."""
         self._current_scope = loop_scope
@@ -434,14 +448,10 @@ class AsyncFixtureWrapper:
 
         # Try to get loop from EventLoopManager for consistency
         try:
-            mgr = EventLoopManager.get_instance()
-            if mgr._loops:
-                # Prefer the most recently added loop (likely the current scope)
-                for key in reversed(list(mgr._loops.keys())):
-                    loop = mgr._loops[key]
-                    if loop and not loop.is_closed():
-                        cls._loop = loop
-                        return cls._loop
+            loop = EventLoopManager.get_current_loop()
+            if loop:
+                cls._loop = loop
+                return cls._loop
         except Exception:
             pass
 
@@ -573,8 +583,14 @@ class AsyncFixtureWrapper:
 
     @classmethod
     def teardown_module_scope(cls) -> None:
-        """Teardown module-scoped fixtures (called on module transition)."""
+        """Teardown module-scoped fixtures (called on module transition).
+
+        Also tears down class-scoped fixtures since class scope is nested
+        inside module scope.
+        """
+        cls._teardown_scope("class")  # Class is inside module
         cls._teardown_scope("module")
+        cls._current_class = None
 
     @classmethod
     def teardown_session_scope(cls) -> None:
@@ -660,10 +676,14 @@ class TachFixturePlugin:
         if inspect.isasyncgen(result) or asyncio.iscoroutine(result):
             scope = getattr(fixturedef, 'scope', 'function')
             fixture_name = fixturedef.argname
-            consumed_value = AsyncFixtureWrapper.consume_async_fixture(
-                fixture_name, result, scope
-            )
-            outcome.force_result(consumed_value)
+            try:
+                consumed_value = AsyncFixtureWrapper.consume_async_fixture(
+                    fixture_name, result, scope
+                )
+                outcome.force_result(consumed_value)
+            except Exception as e:
+                print(f"[tach:harness] ERROR: Failed to consume async fixture '{fixture_name}': {e}", file=sys.stderr)
+                raise
 
 
 # Global instance of the plugin (registered in init_session)
@@ -4347,6 +4367,9 @@ def reset_worker_state() -> bool:
     try:
         # Reset event loop manager to cleanup any lingering loops (Issue #43)
         EventLoopManager.reset()
+
+        # Reset async fixture wrapper state (Issue #43 audit)
+        AsyncFixtureWrapper.reset()
 
         import tach_rust
 

--- a/tests/test_async_fixture.py
+++ b/tests/test_async_fixture.py
@@ -170,3 +170,35 @@ def test_function_scope_second(function_scoped_fixture):
     assert function_scoped_fixture == "function_value_1"
     assert _function_tracker["setup"] == 1
     assert _function_tracker["teardown"] == 0
+
+
+# =============================================================================
+# Batch 2: Indirect Async Dependency Tests (pytest_fixture_setup hook)
+# =============================================================================
+
+
+@pytest.fixture
+async def base_async():
+    """Base async fixture that returns a dict value."""
+    await asyncio.sleep(0)
+    return {"key": "base_value"}
+
+
+@pytest.fixture
+def sync_uses_async(base_async):
+    """Sync fixture that depends on an async fixture.
+
+    This tests the indirect dependency problem: pytest resolves base_async
+    and passes it to this sync fixture. Without the pytest_fixture_setup hook,
+    base_async would be a raw coroutine instead of the resolved value.
+    """
+    return f"got_{base_async['key']}"
+
+
+def test_indirect_async_dependency(sync_uses_async):
+    """Test that sync fixtures can depend on async fixtures.
+
+    This verifies the pytest_fixture_setup hook intercepts async fixtures
+    at resolution time, not just when they're direct dependencies.
+    """
+    assert sync_uses_async == "got_base_value"


### PR DESCRIPTION
## Summary

- Add scope-aware fixture tracking to AsyncFixtureWrapper (session/module/class/function)
- Add pytest_fixture_setup hook for indirect async dependency resolution
- Unify event loop management between AsyncFixtureWrapper and EventLoopManager
- Fix premature teardown of session/module-scoped fixtures

## Problem

AsyncFixtureWrapper had 4 critical design flaws causing ~51 test failures:
1. Scope-unaware teardown - tore down ALL fixtures after each test
2. Indirect dependency gap - only intercepted direct funcargs
3. Event loop fragmentation - two competing loop managers
4. State contamination - _consumed set not properly scoped

## Solution

- `_generators_by_scope` / `_consumed_by_scope` / `_values_by_scope` - nested by scope
- `TachFixturePlugin` with `pytest_fixture_setup` hook intercepts at resolution time
- `EventLoopManager.get_current_loop()` provides encapsulated loop access
- `on_test_start()` handles module/class transitions

## Test plan

- [x] Module-scoped fixtures persist across tests
- [x] Session-scoped fixtures persist across session
- [x] Indirect async dependencies resolved correctly
- [x] Event loop consistency between fixtures and tests
- [x] 801 Rust unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced async fixture support with proper scope management (session, module, class, function levels)
  * Improved event-loop management across test execution
  * Better fixture lifecycle tracking and cleanup

* **Tests**
  * Added comprehensive test coverage for async fixtures across different scopes
  * Added tests for indirect async fixture dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->