### PR TITLE
fix(zygote): call _setup_django_test_db via module ref instead of import

### DIFF
--- a/src/execution/zygote.rs
+++ b/src/execution/zygote.rs
@@ -703,20 +703,14 @@ except Exception as e:
         // Django Test Database: Create test DB after pytest is configured but
         // before workers fork. Reads TACH_REUSE_DB/TACH_CREATE_DB env vars.
         // Connections are closed before fork so workers get fresh FDs.
-        py.run(
-            c_str!(
-                r#"
-try:
-    import tach_harness
-    tach_harness._setup_django_test_db()
-except Exception as e:
-    import sys
-    print(f'[tach:zygote] Django test DB setup error: {e}', file=sys.stderr)
-"#
-            ),
-            None,
-            None,
-        )?;
+        // NOTE: Call through `harness` ref directly — sys.modules registration
+        // happens later, so `import tach_harness` would fail here.
+        if let Err(e) = harness
+            .getattr("_setup_django_test_db")
+            .and_then(|f| f.call0())
+        {
+            eprintln!("[tach:zygote] Django test DB setup error: {e}");
+        }
 
         // HOOK EFFECT BRIDGE (v0.2.0): Retrieve session effects from Python
         // After init_session(), Python has recorded effects in _SESSION_HOOK_EFFECTS.


### PR DESCRIPTION
## Summary

Fixes a silent failure in #88 where `_setup_django_test_db()` was called via `import tach_harness` inside `py.run()`, but `sys.modules["tach_harness"]` registration happens AFTER the call. The import silently failed with `ModuleNotFoundError`, caught by `except`.

**Fix**: Call the function directly through the already-loaded `harness` PyModule reference using `harness.getattr("_setup_django_test_db")?.call0()`.

## Verification

- Django test DB setup now correctly prints `[tach:harness] Setting up Django test database (keepdb=False)` and `[tach:harness] Django test database ready`
- Full Django test suite: **3,589 passed** (up from 377 baseline, criterion was >800)
- 854/854 unit tests pass, fmt ✅, clippy ✅

Refs #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Django test database setup error handling with clearer error reporting to help diagnose setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->