### PR TITLE
fix(scanner): propagate class-level markers to test methods

### DIFF
--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -1368,8 +1368,22 @@ fn parse_module_with_relative_path(abs_path: &Path, rel_path: &Path) -> Result<T
                             if method_name.starts_with("test_") {
                                 let line_number =
                                     get_line_number(&source, func.range.start().to_usize());
-                                let (markers, marker_info) =
+                                let (mut markers, mut marker_info) =
                                     extract_markers_from_decorators(&func.decorator_list);
+
+                                // Merge class-level markers (e.g., @pytest.mark.django_db on the class)
+                                let (class_markers, class_marker_info) =
+                                    extract_markers_from_decorators(&class.decorator_list);
+                                for cm in class_markers {
+                                    if !markers.contains(&cm) {
+                                        markers.push(cm);
+                                    }
+                                }
+                                for cmi in class_marker_info {
+                                    if !marker_info.iter().any(|m| m.name == cmi.name) {
+                                        marker_info.push(cmi);
+                                    }
+                                }
                                 let parametrized_args = extract_injected_args(
                                     &func.decorator_list,
                                     &extract_args_from_arguments(&func.args),
@@ -1446,8 +1460,22 @@ fn parse_module_with_relative_path(abs_path: &Path, rel_path: &Path) -> Result<T
                             if method_name.starts_with("test_") {
                                 let line_number =
                                     get_line_number(&source, func.range.start().to_usize());
-                                let (markers, marker_info) =
+                                let (mut markers, mut marker_info) =
                                     extract_markers_from_decorators(&func.decorator_list);
+
+                                // Merge class-level markers
+                                let (class_markers, class_marker_info) =
+                                    extract_markers_from_decorators(&class.decorator_list);
+                                for cm in class_markers {
+                                    if !markers.contains(&cm) {
+                                        markers.push(cm);
+                                    }
+                                }
+                                for cmi in class_marker_info {
+                                    if !marker_info.iter().any(|m| m.name == cmi.name) {
+                                        marker_info.push(cmi);
+                                    }
+                                }
                                 let parametrized_args = extract_injected_args(
                                     &func.decorator_list,
                                     &extract_args_from_arguments(&func.args),


### PR DESCRIPTION
## Summary

Class-level decorators like `@pytest.mark.django_db(transaction=True)` were not being merged into test methods' `marker_info`, causing `has_django_transaction_marker()` (from #90) to miss them.

Fix: Merge class decorator markers into each method's markers/marker_info for both sync and async test methods.

Refs #82

## Verification

Integration test with 4 Django tests:
- `test_create_user` (transaction=True) — commits data, passes ✅
- `test_no_pollution` — verifies txn_user does NOT leak, passes ✅
- `test_create_and_rollback` — savepoint isolation still works, passes ✅
- `test_no_savepoint_leak` — savepoint user doesn't leak, passes ✅

Queue correctly splits: `3 safe (Hypervisor), 1 toxic (Isolation)`. Toxic worker exits after test.

857/857 unit tests pass, fmt ✅, clippy ✅