### PR TITLE
fix(reporting): TUI hangs for 5s due to blocking socket read

### DIFF
--- a/src/execution/scheduler.rs
+++ b/src/execution/scheduler.rs
@@ -192,8 +192,10 @@ impl Scheduler {
     ) -> Result<Self> {
         let max_workers = log_capture.slot_count();
 
-        // Set read timeout on result socket for crash detection
-        result_socket.set_read_timeout(Some(Duration::from_secs(5)))?;
+        // Set read timeout on result socket for crash detection.
+        // 100ms keeps the scheduler responsive for TUI updates while still
+        // being efficient (the scheduler sleeps 50ms between iterations anyway).
+        result_socket.set_read_timeout(Some(Duration::from_millis(100)))?;
 
         // Set read timeout on cmd socket to prevent indefinite hang if Zygote crashes
         cmd_socket.set_read_timeout(Some(Duration::from_secs(10)))?;

--- a/src/reporting/reporter.rs
+++ b/src/reporting/reporter.rs
@@ -17,6 +17,7 @@ use crate::config::TracebackStyle;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
+use std::time::Duration;
 
 // Re-export TracebackStyle for convenience
 pub use crate::config::TracebackStyle as TbStyle;
@@ -681,6 +682,7 @@ impl ProgressReporter {
                 .unwrap_or_else(|_| ProgressStyle::default_bar())
                 .progress_chars("=>-"),
         );
+        bar.enable_steady_tick(Duration::from_millis(100));
 
         Self {
             bar,
@@ -1040,6 +1042,7 @@ impl TachReporter {
                 .template("{spinner:.green} {msg}")
                 .expect("invalid spinner template"),
         );
+        bar.enable_steady_tick(Duration::from_millis(100));
         Self {
             bar,
             file_results: HashMap::new(),


### PR DESCRIPTION
## Summary
- Reduced socket read timeout from 5s to 100ms in `scheduler.rs` so the scheduler unblocks quickly for TUI updates
- Enabled `enable_steady_tick(100ms)` on both `ProgressReporter` and `TachReporter` ProgressBars so the spinner animates independently of test result arrival

Fixes #81