### PR TITLE
feat(discovery): match pytest collection rules and add list summary

### DIFF
--- a/src/discovery/inheritance.rs
+++ b/src/discovery/inheritance.rs
@@ -11,13 +11,23 @@ pub struct ClassInfo {
     pub is_test_class: bool,
     pub class_markers: (Vec<String>, Vec<MarkerInfo>),
     pub line_number: usize,
+    pub has_testcase_base: bool,
+    pub has_test_false: bool,
+    pub has_init: bool,
+    pub has_new: bool,
+    pub is_abstract: bool,
 }
 
 /// Resolve transitive class inheritance and propagate inherited test methods.
 ///
 /// Two-phase fixed-point algorithm:
-/// 1. Propagate `is_test_class` from parent to child transitively
+/// 1. Propagate `is_test_class` and `has_testcase_base` from parent to child transitively
 /// 2. Copy parent test methods to children (skip overridden methods)
+///
+/// Respects pytest exclusion rules:
+/// - `__test__ = False` prevents collection
+/// - `__init__`/`__new__` prevents collection for non-unittest classes
+/// - Abstract classes (with unresolved `@abstractmethod`) are skipped
 pub fn resolve_inheritance(class_defs: &[ClassInfo]) -> Vec<ClassInfo> {
     let mut resolved: Vec<ClassInfo> = class_defs.to_vec();
 
@@ -29,35 +39,52 @@ pub fn resolve_inheritance(class_defs: &[ClassInfo]) -> Vec<ClassInfo> {
             .push(i);
     }
 
-    // Phase 1: Propagate is_test_class transitively
+    // Phase 1: Propagate is_test_class and has_testcase_base transitively
     loop {
         let mut changed = false;
         for i in 0..resolved.len() {
-            if resolved[i].is_test_class {
-                continue;
-            }
             let bases = resolved[i].bases.clone();
             let child_file = resolved[i].file_path.clone();
             for base_name in &bases {
                 let simple_name = base_name.rsplit('.').next().unwrap_or(base_name);
                 if let Some(indices) = name_to_indices.get(simple_name) {
-                    let is_parent_test_class = indices
+                    let parent_idx = indices
                         .iter()
-                        .find(|&&idx| {
-                            resolved[idx].file_path == child_file && resolved[idx].is_test_class
-                        })
-                        .or_else(|| indices.iter().find(|&&idx| resolved[idx].is_test_class))
-                        .is_some();
-                    if is_parent_test_class {
-                        resolved[i].is_test_class = true;
-                        changed = true;
-                        break;
+                        .find(|&&idx| resolved[idx].file_path == child_file)
+                        .or_else(|| indices.first())
+                        .copied();
+
+                    if let Some(pidx) = parent_idx {
+                        if resolved[pidx].has_testcase_base && !resolved[i].has_testcase_base {
+                            resolved[i].has_testcase_base = true;
+                            changed = true;
+                        }
+                        if !resolved[i].is_test_class && resolved[pidx].is_test_class {
+                            resolved[i].is_test_class = true;
+                            changed = true;
+                        }
                     }
                 }
             }
         }
         if !changed {
             break;
+        }
+    }
+
+    // Phase 1.5: Apply exclusion rules after inheritance propagation
+    for class in resolved.iter_mut() {
+        if class.has_test_false {
+            class.is_test_class = false;
+            continue;
+        }
+        if class.is_abstract {
+            class.is_test_class = false;
+            continue;
+        }
+        // __init__/__new__ only excludes non-unittest classes (pytest behavior)
+        if (class.has_init || class.has_new) && !class.has_testcase_base {
+            class.is_test_class = false;
         }
     }
 
@@ -131,19 +158,27 @@ pub fn apply_resolved_classes(modules: &mut [TestModule], resolved: &[ClassInfo]
         .collect();
 
     for module in modules.iter_mut() {
+        let mut tests_to_remove: HashSet<String> = HashSet::new();
+
         for class_def in &module.class_defs {
             if let Some(resolved_class) =
                 resolved_map.get(&(module.path.clone(), class_def.name.clone()))
             {
+                let class_prefix = format!("{}::", class_def.name);
+
                 if !resolved_class.is_test_class {
+                    for test in &module.tests {
+                        if test.name.starts_with(&class_prefix) {
+                            tests_to_remove.insert(test.name.clone());
+                        }
+                    }
                     continue;
                 }
 
-                let existing_prefix = format!("{}::", class_def.name);
                 let existing_methods: HashSet<String> = module
                     .tests
                     .iter()
-                    .filter(|t| t.name.starts_with(&existing_prefix) || t.name == class_def.name)
+                    .filter(|t| t.name.starts_with(&class_prefix) || t.name == class_def.name)
                     .map(|t| t.name.clone())
                     .collect();
 
@@ -153,6 +188,10 @@ pub fn apply_resolved_classes(modules: &mut [TestModule], resolved: &[ClassInfo]
                     }
                 }
             }
+        }
+
+        if !tests_to_remove.is_empty() {
+            module.tests.retain(|t| !tests_to_remove.contains(&t.name));
         }
     }
 }
@@ -175,17 +214,38 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_class_info_creation() {
-        let info = ClassInfo {
-            name: "TestFoo".to_string(),
-            file_path: PathBuf::from("test_foo.py"),
-            bases: vec!["unittest.TestCase".to_string()],
-            methods: vec![],
-            is_test_class: true,
+    fn make_class(
+        name: &str,
+        file: &str,
+        bases: Vec<String>,
+        methods: Vec<TestCase>,
+        is_test_class: bool,
+    ) -> ClassInfo {
+        ClassInfo {
+            name: name.into(),
+            file_path: file.into(),
+            bases,
+            methods,
+            is_test_class,
             class_markers: (vec![], vec![]),
             line_number: 1,
-        };
+            has_testcase_base: false,
+            has_test_false: false,
+            has_init: false,
+            has_new: false,
+            is_abstract: false,
+        }
+    }
+
+    #[test]
+    fn test_class_info_creation() {
+        let info = make_class(
+            "TestFoo",
+            "test_foo.py",
+            vec!["unittest.TestCase".into()],
+            vec![],
+            true,
+        );
         assert_eq!(info.name, "TestFoo");
         assert!(info.is_test_class);
     }
@@ -193,24 +253,20 @@ mod tests {
     #[test]
     fn test_transitive_test_class_detection() {
         let class_defs = vec![
-            ClassInfo {
-                name: "BaseLoader".into(),
-                file_path: "base.py".into(),
-                bases: vec!["unittest.TestCase".into()],
-                methods: vec![make_test_case("BaseLoader::test_load")],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "CustomLoader".into(),
-                file_path: "custom.py".into(),
-                bases: vec!["BaseLoader".into()],
-                methods: vec![make_test_case("CustomLoader::test_custom")],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
+            make_class(
+                "BaseLoader",
+                "base.py",
+                vec!["unittest.TestCase".into()],
+                vec![make_test_case("BaseLoader::test_load")],
+                true,
+            ),
+            make_class(
+                "CustomLoader",
+                "custom.py",
+                vec!["BaseLoader".into()],
+                vec![make_test_case("CustomLoader::test_custom")],
+                false,
+            ),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
@@ -224,33 +280,27 @@ mod tests {
     #[test]
     fn test_three_level_transitive_inheritance() {
         let class_defs = vec![
-            ClassInfo {
-                name: "GrandParent".into(),
-                file_path: "base.py".into(),
-                bases: vec!["TestCase".into()],
-                methods: vec![make_test_case("GrandParent::test_gp")],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "Parent".into(),
-                file_path: "mid.py".into(),
-                bases: vec!["GrandParent".into()],
-                methods: vec![],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "Child".into(),
-                file_path: "child.py".into(),
-                bases: vec!["Parent".into()],
-                methods: vec![make_test_case("Child::test_child")],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
+            make_class(
+                "GrandParent",
+                "base.py",
+                vec!["TestCase".into()],
+                vec![make_test_case("GrandParent::test_gp")],
+                true,
+            ),
+            make_class(
+                "Parent",
+                "mid.py",
+                vec!["GrandParent".into()],
+                vec![],
+                false,
+            ),
+            make_class(
+                "Child",
+                "child.py",
+                vec!["Parent".into()],
+                vec![make_test_case("Child::test_child")],
+                false,
+            ),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
@@ -263,27 +313,23 @@ mod tests {
     #[test]
     fn test_inherited_methods_propagated() {
         let class_defs = vec![
-            ClassInfo {
-                name: "ReloaderTests".into(),
-                file_path: "base.py".into(),
-                bases: vec![],
-                methods: vec![
+            make_class(
+                "ReloaderTests",
+                "base.py",
+                vec![],
+                vec![
                     make_test_case("ReloaderTests::test_glob"),
                     make_test_case("ReloaderTests::test_glob_recursive"),
                 ],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "StatReloaderTests".into(),
-                file_path: "stat.py".into(),
-                bases: vec!["ReloaderTests".into()],
-                methods: vec![],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 5,
-            },
+                true,
+            ),
+            make_class(
+                "StatReloaderTests",
+                "stat.py",
+                vec!["ReloaderTests".into()],
+                vec![],
+                true,
+            ),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
@@ -307,27 +353,23 @@ mod tests {
     #[test]
     fn test_inherited_methods_not_duplicated_when_overridden() {
         let class_defs = vec![
-            ClassInfo {
-                name: "ParentTests".into(),
-                file_path: "parent.py".into(),
-                bases: vec![],
-                methods: vec![
+            make_class(
+                "ParentTests",
+                "parent.py",
+                vec![],
+                vec![
                     make_test_case("ParentTests::test_foo"),
                     make_test_case("ParentTests::test_bar"),
                 ],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "ChildTests".into(),
-                file_path: "child.py".into(),
-                bases: vec!["ParentTests".into()],
-                methods: vec![make_test_case("ChildTests::test_foo")],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
+                true,
+            ),
+            make_class(
+                "ChildTests",
+                "child.py",
+                vec!["ParentTests".into()],
+                vec![make_test_case("ChildTests::test_foo")],
+                true,
+            ),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
@@ -350,33 +392,21 @@ mod tests {
     #[test]
     fn test_inherited_methods_multi_level() {
         let class_defs = vec![
-            ClassInfo {
-                name: "A".into(),
-                file_path: "a.py".into(),
-                bases: vec!["TestCase".into()],
-                methods: vec![make_test_case("A::test_a")],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "B".into(),
-                file_path: "b.py".into(),
-                bases: vec!["A".into()],
-                methods: vec![make_test_case("B::test_b")],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "C".into(),
-                file_path: "c.py".into(),
-                bases: vec!["B".into()],
-                methods: vec![],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
+            make_class(
+                "A",
+                "a.py",
+                vec!["TestCase".into()],
+                vec![make_test_case("A::test_a")],
+                true,
+            ),
+            make_class(
+                "B",
+                "b.py",
+                vec!["A".into()],
+                vec![make_test_case("B::test_b")],
+                false,
+            ),
+            make_class("C", "c.py", vec!["B".into()], vec![], false),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
@@ -390,24 +420,20 @@ mod tests {
     #[test]
     fn test_non_test_class_not_promoted_without_test_ancestor() {
         let class_defs = vec![
-            ClassInfo {
-                name: "Helper".into(),
-                file_path: "helper.py".into(),
-                bases: vec![],
-                methods: vec![make_test_case("Helper::test_thing")],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "DerivedHelper".into(),
-                file_path: "derived.py".into(),
-                bases: vec!["Helper".into()],
-                methods: vec![],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
+            make_class(
+                "Helper",
+                "helper.py",
+                vec![],
+                vec![make_test_case("Helper::test_thing")],
+                false,
+            ),
+            make_class(
+                "DerivedHelper",
+                "derived.py",
+                vec!["Helper".into()],
+                vec![],
+                false,
+            ),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
@@ -421,38 +447,176 @@ mod tests {
     #[test]
     fn test_same_file_class_preferred_for_inheritance() {
         let class_defs = vec![
-            ClassInfo {
-                name: "Base".into(),
-                file_path: "a.py".into(),
-                bases: vec!["TestCase".into()],
-                methods: vec![make_test_case("Base::test_a")],
-                is_test_class: true,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "Base".into(),
-                file_path: "b.py".into(),
-                bases: vec![],
-                methods: vec![make_test_case("Base::test_b")],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 1,
-            },
-            ClassInfo {
-                name: "Child".into(),
-                file_path: "a.py".into(),
-                bases: vec!["Base".into()],
-                methods: vec![],
-                is_test_class: false,
-                class_markers: (vec![], vec![]),
-                line_number: 10,
-            },
+            make_class(
+                "Base",
+                "a.py",
+                vec!["TestCase".into()],
+                vec![make_test_case("Base::test_a")],
+                true,
+            ),
+            make_class(
+                "Base",
+                "b.py",
+                vec![],
+                vec![make_test_case("Base::test_b")],
+                false,
+            ),
+            make_class("Child", "a.py", vec!["Base".into()], vec![], false),
         ];
 
         let resolved = resolve_inheritance(&class_defs);
         let child = resolved.iter().find(|c| c.name == "Child").unwrap();
         assert!(child.is_test_class);
         assert!(child.methods.iter().any(|m| m.name == "Child::test_a"));
+    }
+
+    #[test]
+    fn test_test_false_prevents_collection() {
+        let mut class = make_class(
+            "TestFoo",
+            "test_foo.py",
+            vec!["TestCase".into()],
+            vec![make_test_case("TestFoo::test_bar")],
+            true,
+        );
+        class.has_test_false = true;
+        class.has_testcase_base = true;
+
+        let resolved = resolve_inheritance(&[class]);
+        assert!(!resolved[0].is_test_class);
+    }
+
+    #[test]
+    fn test_init_excludes_non_unittest_class() {
+        let mut class = make_class(
+            "TestWidget",
+            "test_widget.py",
+            vec![],
+            vec![make_test_case("TestWidget::test_render")],
+            true,
+        );
+        class.has_init = true;
+
+        let resolved = resolve_inheritance(&[class]);
+        assert!(!resolved[0].is_test_class);
+    }
+
+    #[test]
+    fn test_init_does_not_exclude_unittest_class() {
+        let mut class = make_class(
+            "TestWidget",
+            "test_widget.py",
+            vec!["TestCase".into()],
+            vec![make_test_case("TestWidget::test_render")],
+            true,
+        );
+        class.has_init = true;
+        class.has_testcase_base = true;
+
+        let resolved = resolve_inheritance(&[class]);
+        assert!(resolved[0].is_test_class);
+    }
+
+    #[test]
+    fn test_abstract_class_excluded() {
+        let mut class = make_class(
+            "TestBase",
+            "test_base.py",
+            vec!["TestCase".into()],
+            vec![make_test_case("TestBase::test_stuff")],
+            true,
+        );
+        class.is_abstract = true;
+        class.has_testcase_base = true;
+
+        let resolved = resolve_inheritance(&[class]);
+        assert!(!resolved[0].is_test_class);
+    }
+
+    #[test]
+    fn test_new_excludes_non_unittest_class() {
+        let mut class = make_class(
+            "TestSingleton",
+            "test_s.py",
+            vec![],
+            vec![make_test_case("TestSingleton::test_instance")],
+            true,
+        );
+        class.has_new = true;
+
+        let resolved = resolve_inheritance(&[class]);
+        assert!(!resolved[0].is_test_class);
+    }
+
+    #[test]
+    fn test_mixin_class_not_collected_without_testcase_base() {
+        let class_defs = vec![
+            make_class(
+                "IntegrationTests",
+                "test_auto.py",
+                vec![],
+                vec![
+                    make_test_case("IntegrationTests::test_glob"),
+                    make_test_case("IntegrationTests::test_multiple"),
+                ],
+                false,
+            ),
+            {
+                let mut child = make_class(
+                    "WatchmanReloaderTests",
+                    "test_auto.py",
+                    vec!["ReloaderTests".into(), "IntegrationTests".into()],
+                    vec![],
+                    true,
+                );
+                child.has_testcase_base = true;
+                child
+            },
+        ];
+
+        let resolved = resolve_inheritance(&class_defs);
+        let mixin = resolved
+            .iter()
+            .find(|c| c.name == "IntegrationTests")
+            .unwrap();
+        assert!(
+            !mixin.is_test_class,
+            "Mixin without TestCase base should not be collected"
+        );
+        let child = resolved
+            .iter()
+            .find(|c| c.name == "WatchmanReloaderTests")
+            .unwrap();
+        assert!(child.is_test_class);
+    }
+
+    #[test]
+    fn test_testcase_base_propagated_transitively() {
+        let class_defs = vec![
+            {
+                let mut c = make_class(
+                    "BaseTest",
+                    "base.py",
+                    vec!["TestCase".into()],
+                    vec![make_test_case("BaseTest::test_base")],
+                    true,
+                );
+                c.has_testcase_base = true;
+                c
+            },
+            make_class("MidLevel", "mid.py", vec!["BaseTest".into()], vec![], false),
+            make_class(
+                "LeafTest",
+                "leaf.py",
+                vec!["MidLevel".into()],
+                vec![],
+                false,
+            ),
+        ];
+
+        let resolved = resolve_inheritance(&class_defs);
+        let leaf = resolved.iter().find(|c| c.name == "LeafTest").unwrap();
+        assert!(leaf.is_test_class);
+        assert!(leaf.has_testcase_base);
     }
 }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -18,30 +18,27 @@ pub mod loader;
 pub mod resolver;
 pub mod scanner;
 
-/// Check whether a class name follows pytest's test class naming conventions.
+/// Check whether a class name matches pytest's `python_classes` prefix convention.
 ///
-/// Pytest discovers test classes through two mechanisms:
-/// 1. **Name matching**: classes whose name starts with `Test` (the `python_classes` default)
-/// 2. **Inheritance**: any `unittest.TestCase` subclass, regardless of name
+/// Pytest's default `python_classes = ["Test"]` uses **prefix matching**:
+/// `name.starts_with("Test")`. This matches `TestFoo`, `Testing`, etc.
 ///
-/// Since tach performs static AST analysis without import-time MRO resolution,
-/// we approximate mechanism (2) by also matching common suffix conventions:
-/// - `*Test`     (e.g. `LoginTest`, `FormTest`)
-/// - `*Tests`    (e.g. `LoginTests`, `ModelFormTests`)
-/// - `*TestCase` (e.g. `AutodiscoverModulesTestCase`, `MyFeatureTestCase`)
-///
-/// The name must be at least 5 characters so that bare `"Test"` alone doesn't match —
-/// a descriptive component is always required.
+/// For classes that DON'T start with `Test` but inherit from `unittest.TestCase`,
+/// pytest's unittest plugin collects them via a separate path that bypasses
+/// name matching entirely. We handle that via `has_testcase_base()` in the scanner.
 #[inline]
 pub fn is_test_class(name: &str) -> bool {
-    let len = name.len();
-    if len < 5 {
-        return false;
-    }
-    name.starts_with("Test")
-        || name.ends_with("Test")
-        || name.ends_with("Tests")
-        || name.ends_with("TestCase")
+    name.starts_with("Test") && name.len() >= 5
+}
+
+/// Check whether a class name follows `*TestCase` suffix conventions.
+///
+/// This matches classes like `MyFeatureTestCase` which strongly imply
+/// unittest.TestCase lineage. Used together with `has_testcase_base()` to
+/// identify test classes that don't follow the `Test*` prefix convention.
+#[inline]
+pub fn is_testcase_by_suffix(name: &str) -> bool {
+    name.ends_with("TestCase") && name.len() > 8
 }
 
 /// Check whether any base class in the AST suggests a `unittest.TestCase` lineage.

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -370,6 +370,22 @@ fn has_fixture_decorator(decorators: &[ast::Expr]) -> bool {
     decorators.iter().any(is_fixture_decorator)
 }
 
+fn is_abstractmethod_decorator(expr: &ast::Expr) -> bool {
+    match expr {
+        ast::Expr::Name(name) => name.id.as_str() == "abstractmethod",
+        ast::Expr::Attribute(attr) => attr.attr.as_str() == "abstractmethod",
+        _ => false,
+    }
+}
+
+fn has_abc_base(bases: &[ast::Expr]) -> bool {
+    bases.iter().any(|base| match base {
+        ast::Expr::Name(name) => matches!(name.id.as_str(), "ABC" | "ABCMeta"),
+        ast::Expr::Attribute(attr) => matches!(attr.attr.as_str(), "ABC" | "ABCMeta"),
+        _ => false,
+    })
+}
+
 /// Extract fixture scope from decorators
 fn extract_scope_from_decorators(decorators: &[ast::Expr]) -> FixtureScope {
     for decorator in decorators {
@@ -1346,8 +1362,10 @@ fn parse_module_with_relative_path(abs_path: &Path, rel_path: &Path) -> Result<T
             }
             ast::Stmt::ClassDef(class) => {
                 let class_name = class.name.as_str();
-                let is_test =
-                    super::is_test_class(class_name) || super::has_testcase_base(&class.bases);
+                let has_tc_base = super::has_testcase_base(&class.bases);
+                let is_test = super::is_test_class(class_name)
+                    || super::is_testcase_by_suffix(class_name)
+                    || has_tc_base;
 
                 // Extract base class names as strings for inheritance resolution
                 let base_names: Vec<String> = class
@@ -1384,6 +1402,45 @@ fn parse_module_with_relative_path(abs_path: &Path, rel_path: &Path) -> Result<T
                 let class_line = get_line_number(&source, class.range.start().to_usize());
                 let (class_level_markers, class_level_marker_info) =
                     extract_markers_from_decorators(&class.decorator_list);
+
+                let mut has_test_false = false;
+                let mut has_init = false;
+                let mut has_new = false;
+                let mut has_abstractmethod = false;
+
+                for stmt in &class.body {
+                    match stmt {
+                        ast::Stmt::Assign(assign) => {
+                            // Detect `__test__ = False`
+                            if assign.targets.len() == 1
+                                && let ast::Expr::Name(name) = &assign.targets[0]
+                                && name.id.as_str() == "__test__"
+                                && let ast::Expr::Constant(c) = assign.value.as_ref()
+                                && let ast::Constant::Bool(false) = &c.value
+                            {
+                                has_test_false = true;
+                            }
+                        }
+                        ast::Stmt::FunctionDef(func) => {
+                            match func.name.as_str() {
+                                "__init__" => has_init = true,
+                                "__new__" => has_new = true,
+                                _ => {}
+                            }
+                            if func.decorator_list.iter().any(is_abstractmethod_decorator) {
+                                has_abstractmethod = true;
+                            }
+                        }
+                        ast::Stmt::AsyncFunctionDef(func) => {
+                            if func.decorator_list.iter().any(is_abstractmethod_decorator) {
+                                has_abstractmethod = true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                let is_abstract_class = has_abstractmethod || has_abc_base(&class.bases);
 
                 // Collect test methods from the class body
                 let mut class_methods: Vec<TestCase> = vec![];
@@ -1581,6 +1638,11 @@ fn parse_module_with_relative_path(abs_path: &Path, rel_path: &Path) -> Result<T
                     is_test_class: is_test,
                     class_markers: (class_level_markers, class_level_marker_info),
                     line_number: class_line,
+                    has_testcase_base: has_tc_base,
+                    has_test_false,
+                    has_init,
+                    has_new,
+                    is_abstract: is_abstract_class,
                 });
 
                 // Only add tests to module for classes already identified as test classes
@@ -2952,12 +3014,35 @@ def test_errors(exc):
 
     // =========================================================================
     // Suffix-based test class discovery (Issue #80)
+    // With pytest-matching, suffix-only classes (no TestCase base) are NOT
+    // collected. They only contribute tests via inheritance resolution.
     // =========================================================================
 
     #[test]
-    fn test_parse_class_ending_with_test() {
+    fn test_parse_class_ending_with_test_no_base() {
         let source = r#"
 class LoginTest:
+    def test_valid_credentials(self):
+        pass
+
+    def test_invalid_password(self):
+        pass
+"#;
+        let module = parse_source(source);
+        assert_eq!(
+            module.tests.len(),
+            0,
+            "Suffix-only class without TestCase base should not be collected"
+        );
+        assert_eq!(module.class_defs.len(), 1);
+        assert_eq!(module.class_defs[0].methods.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_class_ending_with_test_with_testcase_base() {
+        let source = r#"
+import unittest
+class LoginTest(unittest.TestCase):
     def test_valid_credentials(self):
         pass
 
@@ -2981,7 +3066,7 @@ class LoginTest:
     }
 
     #[test]
-    fn test_parse_class_ending_with_tests() {
+    fn test_parse_class_ending_with_tests_no_base() {
         let source = r#"
 class ModelFormTests:
     def test_form_valid(self):
@@ -2991,25 +3076,14 @@ class ModelFormTests:
         pass
 "#;
         let module = parse_source(source);
-        assert_eq!(module.tests.len(), 2);
-        assert!(
-            module
-                .tests
-                .iter()
-                .any(|t| t.name == "ModelFormTests::test_form_valid")
-        );
-        assert!(
-            module
-                .tests
-                .iter()
-                .any(|t| t.name == "ModelFormTests::test_form_invalid")
-        );
+        assert_eq!(module.tests.len(), 0);
+        assert_eq!(module.class_defs[0].methods.len(), 2);
     }
 
     #[test]
     fn test_parse_suffix_class_excludes_non_test_methods() {
         let source = r#"
-class PermissionTests:
+class PermissionTests(TestCase):
     def test_access_denied(self):
         pass
 
@@ -3025,38 +3099,46 @@ class PermissionTests:
     }
 
     #[test]
-    fn test_parse_suffix_class_async_method() {
+    fn test_parse_suffix_class_async_method_no_base() {
         let source = r#"
 class WebSocketTest:
     async def test_connect(self, client):
         await client.connect()
 "#;
         let module = parse_source(source);
-        assert_eq!(module.tests.len(), 1);
-        assert_eq!(module.tests[0].name, "WebSocketTest::test_connect");
-        assert!(module.tests[0].is_async);
-        assert_eq!(module.tests[0].dependencies, vec!["client"]);
+        assert_eq!(
+            module.tests.len(),
+            0,
+            "Suffix-only class without TestCase base should not be collected"
+        );
+        assert_eq!(module.class_defs[0].methods.len(), 1);
+        assert!(module.class_defs[0].methods[0].is_async);
     }
 
     #[test]
     fn test_is_test_class() {
         use crate::discovery::is_test_class;
+        use crate::discovery::is_testcase_by_suffix;
 
         assert!(is_test_class("TestLogin"));
         assert!(is_test_class("TestModelForm"));
-        assert!(is_test_class("LoginTest"));
-        assert!(is_test_class("ModelFormTests"));
-        assert!(is_test_class("PermissionTests"));
-        assert!(is_test_class("AutodiscoverModulesTestCase"));
-        assert!(is_test_class("MyFeatureTestCase"));
-        assert!(is_test_class("JSONNormalizeTestCase"));
+        assert!(is_test_class("Tests"));
+
+        // is_test_class is prefix-only — suffix patterns use is_testcase_by_suffix
+        assert!(!is_test_class("LoginTest"));
+        assert!(!is_test_class("ModelFormTests"));
+        assert!(!is_test_class("PermissionTests"));
+
+        assert!(is_testcase_by_suffix("AutodiscoverModulesTestCase"));
+        assert!(is_testcase_by_suffix("MyFeatureTestCase"));
+        assert!(is_testcase_by_suffix("JSONNormalizeTestCase"));
+        assert!(!is_testcase_by_suffix("TestCase"));
 
         assert!(!is_test_class("MyClass"));
         assert!(!is_test_class("Helper"));
         assert!(!is_test_class("Contest"));
         assert!(!is_test_class("Fastest"));
         assert!(!is_test_class("Test"));
-        assert!(is_test_class("Tests"));
         assert!(!is_test_class("Tes"));
     }
 
@@ -3303,5 +3385,93 @@ class BaseLoader:
         assert!(!base.is_test_class);
         assert_eq!(base.methods.len(), 2);
         assert_eq!(module.tests.len(), 0);
+    }
+
+    #[test]
+    fn test_test_false_attribute_detected() {
+        let source = r#"
+class TestHidden:
+    __test__ = False
+    def test_something(self):
+        pass
+"#;
+        let module = parse_source(source);
+        let class = &module.class_defs[0];
+        assert!(class.has_test_false);
+        assert_eq!(class.methods.len(), 1);
+    }
+
+    #[test]
+    fn test_init_method_detected() {
+        let source = r#"
+class TestWidget:
+    def __init__(self, name):
+        self.name = name
+    def test_render(self):
+        pass
+"#;
+        let module = parse_source(source);
+        let class = &module.class_defs[0];
+        assert!(class.has_init);
+    }
+
+    #[test]
+    fn test_new_method_detected() {
+        let source = r#"
+class TestSingleton:
+    def __new__(cls):
+        return super().__new__(cls)
+    def test_instance(self):
+        pass
+"#;
+        let module = parse_source(source);
+        let class = &module.class_defs[0];
+        assert!(class.has_new);
+    }
+
+    #[test]
+    fn test_abstract_class_detected_via_decorator() {
+        let source = r#"
+import abc
+
+class TestBase:
+    @abc.abstractmethod
+    def test_something(self):
+        pass
+"#;
+        let module = parse_source(source);
+        let class = &module.class_defs[0];
+        assert!(class.is_abstract);
+    }
+
+    #[test]
+    fn test_abstract_class_detected_via_abc_base() {
+        let source = r#"
+from abc import ABC
+
+class TestBase(ABC):
+    def test_something(self):
+        pass
+"#;
+        let module = parse_source(source);
+        let class = &module.class_defs[0];
+        assert!(class.is_abstract);
+    }
+
+    #[test]
+    fn test_testcase_suffix_with_testcase_base_is_collected() {
+        let source = r#"
+import unittest
+
+class AutodiscoverModulesTestCase(unittest.TestCase):
+    def test_discover(self):
+        pass
+"#;
+        let module = parse_source(source);
+        assert_eq!(module.tests.len(), 1);
+        assert_eq!(
+            module.tests[0].name,
+            "AutodiscoverModulesTestCase::test_discover"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -773,6 +773,12 @@ fn handle_list_command(
                 eprintln!("{}::{}", module.path.display(), test.name);
             }
         }
+        eprintln!();
+        eprintln!(
+            "Discovered {} tests in {} files",
+            discovery_result.test_count(),
+            discovery_result.modules.len()
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Match pytest's exact test class collection rules to eliminate false positives
- Add `Discovered X tests in Y files` summary to `tach list` output

## Changes

### Discovery Rules (pytest-compatible)
- `is_test_class()` is now prefix-only (`Test*`), matching pytest's `python_classes = ["Test"]` default
- Suffix patterns (`*Test`, `*Tests`) no longer falsely collect mixin classes without TestCase bases
- New `is_testcase_by_suffix()` for `*TestCase` suffix (implies unittest lineage)
- AST detection for `__test__ = False`, `__init__`, `__new__`, `@abstractmethod`, `abc.ABC` base
- New `ClassInfo` fields: `has_testcase_base`, `has_test_false`, `has_init`, `has_new`, `is_abstract`
- Exclusion rules applied in inheritance resolution Phase 1.5:
  - `__test__ = False` → excluded unconditionally
  - `is_abstract` → excluded unconditionally
  - `has_init`/`has_new` → excluded for non-unittest classes only (matches pytest behavior)
- `apply_resolved_classes()` now removes tests from classes excluded during resolution

### List Summary
- `tach list` prints `Discovered X tests in Y files` after test listing

## Verification
- **887/887 unit tests pass** (14 new tests added)
- **Clippy clean**, **fmt clean**
- Django `utils_tests/` comparison:
  - Before: tach 689 vs pytest 611 (gap: 78)
  - After: tach 682 vs pytest 611 (gap: 71)
  - 7-test mixin gap (`IntegrationTests`) **fixed**
  - Remaining 71 are from `test_lazyobject.py` / `test_simplelazyobject.py` (Django import errors, not a tach bug)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added summary output displaying total discovered tests and files.

* **Improvements**
  * Enhanced test discovery to properly identify unittest-style test classes using TestCase naming convention.
  * Improved test class filtering to exclude abstract classes, classes marked with `__test__=False`, and classes with `__init__` or `__new__` methods when not inheriting from TestCase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->